### PR TITLE
Refactor function arguments for `allowed` method

### DIFF
--- a/lib/can.js
+++ b/lib/can.js
@@ -1,15 +1,16 @@
 const { get } = require('lodash');
 const { allowed } = require('./utils');
 
-const can = permissions => (user, task, params) => {
-
-  const establishment = (user.establishments || []).find(e => e.id === parseInt(params.establishment, 10)) || {};
+const can = permissions => (user, task, subject) => {
 
   if (!user) {
     const err = new Error('Unknown user');
     err.status = 400;
     return Promise.reject(err);
   }
+
+  const establishment = (user.establishments || []).find(e => e.id === parseInt(subject.establishment, 10)) || {};
+
   const settings = get(permissions, task);
   if (!settings) {
     const err = new Error(`Unknown task: ${task}`);
@@ -20,9 +21,11 @@ const can = permissions => (user, task, params) => {
   return Promise.resolve()
     .then(() => allowed({
       roles: settings,
-      userRole: establishment.role,
-      userId: user.id,
-      ...params
+      user: {
+        ...user,
+        role: establishment.role
+      },
+      subject
     }));
 };
 

--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -11,7 +11,10 @@ module.exports = permissions => {
         [e.id]: tasks.filter(task => {
           return allowed({
             roles: get(permissions, task),
-            userRole: e.role
+            user: {
+              ...user,
+              role: e.role
+            }
           });
         })
       };

--- a/lib/utils/allowed.js
+++ b/lib/utils/allowed.js
@@ -1,17 +1,17 @@
 const { some } = require('lodash');
 
-module.exports = ({ roles, userRole, userId, id }) => {
+module.exports = ({ roles, user, subject }) => {
   return some(roles, role => {
     if (role === '*') {
       return true;
     }
     const scope = role.split(':')[0];
     const level = role.split(':')[1];
-    if (scope === 'establishment' && userRole) {
-      return level === '*' || userRole === level;
+    if (scope === 'establishment' && user.role) {
+      return level === '*' || user.role === level;
     }
     if (scope === 'profile' && level === 'own') {
-      return userId === id;
+      return user.id && user.id === subject.id;
     }
   });
 };


### PR DESCRIPTION
The parameters for the `allowed` function had been destructured to the extent of a) having convoluted names - e.g. `userRole`, `userId`, and b) being occasionally meaningless without context - e.g. `id` for profile id.

Add some structure to the arguments back so that there are three arguments: the task at hand, the user making the request, and the parameters of the request subject.

This allows context for variables like `id` - the id of the request subject.