### PR TITLE
Add support for non-establishment scoped permissions

### DIFF
--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -5,7 +5,7 @@ module.exports = permissions => {
   const tasks = traverse(permissions);
 
   return user => {
-    return user.establishments.reduce((obj, e) => {
+    const establishmentPermissions = user.establishments.reduce((obj, e) => {
       return {
         ...obj,
         [e.id]: tasks.filter(task => {
@@ -16,5 +16,15 @@ module.exports = permissions => {
         })
       };
     }, {});
+    const globalPermissions = tasks.filter(task => {
+      return allowed({
+        roles: get(permissions, task),
+        user
+      });
+    });
+    return {
+      ...establishmentPermissions,
+      global: globalPermissions
+    };
   };
 };

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -208,11 +208,10 @@ describe('API', () => {
         .get('/')
         .expect(200)
         .expect(response => {
-          assert.deepEqual(response.body, {
-            100: [
-              'task3.task3a'
-            ]
-          });
+          assert(response.body.hasOwnProperty(100), 'response contains a section for establishment `100`');
+          assert.deepEqual(response.body[100], [
+            'task3.task3a'
+          ]);
         });
     });
 
@@ -237,11 +236,29 @@ describe('API', () => {
         .get('/')
         .expect(200)
         .expect(response => {
-          assert.deepEqual(response.body, {
-            100: ['task3.task3a'],
-            101: ['task1', 'task3.task3a'],
-            102: ['task3.task3a']
-          });
+          assert(response.body.hasOwnProperty(100), 'response contains a section for establishment `100`');
+          assert(response.body.hasOwnProperty(101), 'response contains a section for establishment `101`');
+          assert(response.body.hasOwnProperty(102), 'response contains a section for establishment `102`');
+          assert.deepEqual(response.body[100], ['task3.task3a']);
+          assert.deepEqual(response.body[101], ['task1', 'task3.task3a']);
+          assert.deepEqual(response.body[102], ['task3.task3a']);
+        });
+    });
+
+    it('includes global tasks which are not scoped under an establishment', () => {
+      stubProfile(this.api.db.Profile, {
+        establishments: [
+          {
+            id: 100,
+            role: 'basic'
+          }
+        ]
+      });
+      return supertest(this.app)
+        .get('/')
+        .expect(200)
+        .expect(response => {
+          assert(response.body.hasOwnProperty('global'), 'response contains a section for globally allowed tasks');
         });
     });
   });


### PR DESCRIPTION
Certain permissions are not acquired by virtue of a user being a member of a particular establishment (in particular internal users with global permissions) and so need to be defined without being scoped beneath a particular establishment.