### PR TITLE
Set default values for user and subject params in `allowed`

### DIFF
--- a/lib/utils/allowed.js
+++ b/lib/utils/allowed.js
@@ -1,6 +1,6 @@
 const { some } = require('lodash');
 
-module.exports = ({ roles, user, subject }) => {
+module.exports = ({ roles, user = {}, subject = {} }) => {
   return some(roles, role => {
     if (role === '*') {
       return true;

--- a/test/allowed.spec.js
+++ b/test/allowed.spec.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+
+const allowed = require('../lib/utils/allowed');
+
+describe('allowed', () => {
+
+  it('returns false for profile scoped tasks if no profile is provided', () => {
+    const isAllowed = allowed({
+      roles: ['profile.own'],
+      user: {
+        id: 'abc123'
+      }
+    });
+    assert.equal(isAllowed, false);
+  });
+
+});


### PR DESCRIPTION
The subject is not always defined - in particular when called by `getTasks`, which has no particular context, so allow it to be undefined without failing.