### PR TITLE
Throw 400 error from `getTasks` if there is no user

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -46,8 +46,9 @@ module.exports = settings => {
   });
 
   app.get('/', (req, res, next) => {
-    const tasks = getUserTasks(req.profile);
-    res.json(tasks);
+    getUserTasks(req.profile)
+      .then(allowedTasks => res.json(allowedTasks))
+      .catch(next);
   });
 
   app.use(errorHandler());

--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -5,6 +5,12 @@ module.exports = permissions => {
   const tasks = traverse(permissions);
 
   return user => {
+    if (!user) {
+      const err = new Error('Unknown user');
+      err.status = 400;
+      return Promise.reject(err);
+    }
+
     const establishmentPermissions = user.establishments.reduce((obj, e) => {
       return {
         ...obj,
@@ -25,9 +31,9 @@ module.exports = permissions => {
         user
       });
     });
-    return {
+    return Promise.resolve({
       ...establishmentPermissions,
       global: globalPermissions
-    };
+    });
   };
 };

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -261,6 +261,13 @@ describe('API', () => {
           assert(response.body.hasOwnProperty('global'), 'response contains a section for globally allowed tasks');
         });
     });
+
+    it('returns 400 if the profile cannot be found', () => {
+      stubProfile(this.api.db.Profile, null);
+      return supertest(this.app)
+        .get('/')
+        .expect(400);
+    });
   });
 
 });


### PR DESCRIPTION
This makes it consistent with the response for a particular task