### PR TITLE
Add basic permissions as well as advanced permissions for ASRU users

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,14 +24,14 @@ module.exports = {
       invite: ['establishment:admin'],
       read: {
         all: ['asru:*', 'establishment:admin', 'establishment:read'],
-        basic: ['establishment:*']
+        basic: ['asru:*', 'establishment:*']
       },
       update: ['profile:own']
     },
     project: {
       read: {
         all: ['asru:*', 'establishment:admin', 'establishment:read'],
-        basic: ['establishment:*']
+        basic: ['asru:*', 'establishment:*']
       }
     },
     establishment: {


### PR DESCRIPTION
Some parts of the UI determine visibility of components by only checking for basic permissions, so navigation elements were being hidden that should have been visible.