### PR TITLE
Expand `profile.read.all` permissions to include NTCOs

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,7 +24,7 @@ module.exports = {
     profile: {
       invite: ['establishment:admin', 'asru:*'],
       read: {
-        all: ['asru:*', 'establishment:admin', 'establishment:read'],
+        all: ['asru:*', 'establishment:admin', 'establishment:read', 'establishment:role:ntco'],
         basic: ['asru:*', 'establishment:*']
       },
       update: ['profile:own'],

--- a/lib/api.js
+++ b/lib/api.js
@@ -18,7 +18,7 @@ module.exports = settings => {
   app.use((req, res, next) => {
     return Profile.query()
       .where({ userId: req.user.id })
-      .eager('establishments')
+      .eager('[establishments,roles]')
       .then(profiles => profiles[0])
       .then(profile => {
         req.profile = profile;

--- a/lib/can.js
+++ b/lib/can.js
@@ -8,8 +8,9 @@ const can = permissions => (user, task, subject) => {
     err.status = 400;
     return Promise.reject(err);
   }
-
-  const establishment = (user.establishments || []).find(e => e.id === parseInt(subject.establishment, 10)) || {};
+  const establishmentId = parseInt(subject.establishment, 10);
+  const establishment = (user.establishments || []).find(e => e.id === establishmentId) || {};
+  const roles = (user.roles || []).filter(role => role.establishmentId === establishmentId);
 
   const settings = get(permissions, task);
   if (!settings) {
@@ -23,6 +24,7 @@ const can = permissions => (user, task, subject) => {
       roles: settings,
       user: {
         ...user,
+        roles,
         role: establishment.role
       },
       subject

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -2,7 +2,7 @@ module.exports = () => {
 
   return (error, req, res, next) => {
     if (typeof req.log === 'function') {
-      req.log('error', error);
+      req.log('error', { message: error.message, stack: error.stack });
     }
     res.status(error.status || 500);
     res.json({ message: error.message });

--- a/lib/utils/allowed.js
+++ b/lib/utils/allowed.js
@@ -5,8 +5,13 @@ module.exports = ({ roles, user = {}, subject = {} }) => {
     if (role === '*') {
       return true;
     }
-    const scope = role.split(':')[0];
-    const level = role.split(':')[1];
+    const pieces = role.split(':');
+    const scope = pieces[0];
+    const level = pieces[1];
+    if (scope === 'establishment' && level === 'role') {
+      const roleType = pieces[2];
+      return user.roles && user.roles.find(r => r.type === roleType);
+    }
     if (scope === 'establishment' && user.role) {
       return level === '*' || user.role === level;
     }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 
 const { get } = require('lodash');
 const { permissions } = require('../config');
-const { externalPermissions } = require('@asl/constants');
+const { externalPermissions, roles } = require('@asl/constants');
 const { traverse } = require('../lib/utils');
 
 describe('Task configuration', () => {
@@ -11,11 +11,16 @@ describe('Task configuration', () => {
 
   tasks.forEach(task => {
     it(`${task}: only has pre-defined establishment permissions`, () => {
-      const roles = get(permissions, task);
-      roles.forEach(role => {
-        if (role.match(/^estabishment:(.*)$/)) {
-          const type = role.split(':')[1];
-          assert.ok(externalPermissions.includes(type), `${type} is included in external permissions allowed roles`);
+      const permissionTypes = get(permissions, task);
+      permissionTypes.forEach(type => {
+        if (type.match(/^estabishment:(.*)$/)) {
+          const level = type.split(':')[1];
+          if (level === 'role') {
+            const roleType = type.split(':')[2];
+            assert.ok(roles.includes(roleType), `${roleType} should be included in defined roles`);
+          } else {
+            assert.ok(externalPermissions.includes(level), `${level} should be included in defined permissions levels`);
+          }
         }
       });
     });


### PR DESCRIPTION
Adds a new permissions definition of `establishment:role:<type>` which allows users who hold the defined role to perform the relevant task.