### PR TITLE
Include error status in logs

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,10 +1,11 @@
 module.exports = () => {
 
   return (error, req, res, next) => {
+    const status = error.status || 500;
     if (typeof req.log === 'function') {
-      req.log('error', { message: error.message, stack: error.stack });
+      req.log('error', { message: error.message, stack: error.stack, status });
     }
-    res.status(error.status || 500);
+    res.status(status);
     res.json({ message: error.message });
   };
 


### PR DESCRIPTION
This prevents BAU 403 errors being included in error monitoring searches that exclude 4xx errors.