### PR TITLE
Allow `project:own` permissions to fall back to `id` param

### DIFF
--- a/lib/utils/allowed.js
+++ b/lib/utils/allowed.js
@@ -61,12 +61,17 @@ function roleIsAllowed({ db, model, permission, user: unscoped, subject = {} }) 
           .then(result => user.id === result.profileId);
       }
       if (scope === 'profile' && level === 'own') {
-        return user.id && (user.id === subject.profileId || user.id === subject.id);
+        const id = subject.profileId || subject.id;
+        return user.id && user.id === id;
       }
-      if (scope === 'project' && level === 'own' && subject.projectId) {
+      if (scope === 'project' && level === 'own') {
+        const id = subject.projectId || subject.id;
+        if (!id) {
+          return false;
+        }
         const { Project } = db;
         return Promise.resolve()
-          .then(() => Project.query().findById(subject.projectId).select('licenceHolderId'))
+          .then(() => Project.query().findById(id).select('licenceHolderId'))
           .then(result => user.id === result.licenceHolderId);
       }
       if (scope === 'asru' && user.asruUser) {


### PR DESCRIPTION
All the other things which accept a `thingId` param will fall back to `id`. Add this to `project:own` permissions as well.