### PR TITLE
Bugfix - query with deleted

### DIFF
--- a/lib/utils/allowed.js
+++ b/lib/utils/allowed.js
@@ -15,7 +15,7 @@ function scopedUserHasPermission(Model, id, user, level) {
     return Promise.resolve(false);
   }
   return Promise.resolve()
-    .then(() => Model.query().findById(id).select('establishmentId'))
+    .then(() => Model.queryWithDeleted().findById(id).select('establishmentId'))
     .then(result => {
       if (!result) {
         return false;
@@ -51,7 +51,7 @@ function roleIsAllowed({ db, model, permission, user: unscoped, subject = {} }) 
             return false;
           }
           return Promise.resolve()
-            .then(() => db.ProjectVersion.query().findById(id).select(
+            .then(() => db.ProjectVersion.queryWithDeleted().findById(id).select(
               ref('data:transferToEstablishment')
                 .castInt()
                 .as('transferToEstablishment')
@@ -81,7 +81,7 @@ function roleIsAllowed({ db, model, permission, user: unscoped, subject = {} }) 
       if (scope === 'pil' && level === 'own' && subject.pilId) {
         const { PIL } = db;
         return Promise.resolve()
-          .then(() => PIL.query().findById(subject.pilId).select('profileId'))
+          .then(() => PIL.queryWithDeleted().findById(subject.pilId).select('profileId'))
           .then(result => user.id === result.profileId);
       }
       if (scope === 'profile' && level === 'own') {
@@ -95,7 +95,7 @@ function roleIsAllowed({ db, model, permission, user: unscoped, subject = {} }) 
         }
         const { Project } = db;
         return Promise.resolve()
-          .then(() => Project.query().findById(id).select('licenceHolderId'))
+          .then(() => Project.queryWithDeleted().findById(id).select('licenceHolderId'))
           .then(result => user.id === result.licenceHolderId);
       }
       if (scope === 'asru' && user.asruUser) {

--- a/test/allowed.spec.js
+++ b/test/allowed.spec.js
@@ -33,7 +33,7 @@ describe('allowed', () => {
       selectStub = sinon.stub();
       const stubModels = {
         PIL: {
-          query: sinon.stub().returns({
+          queryWithDeleted: sinon.stub().returns({
             findById: findStub.returns({
               select: selectStub
             })
@@ -87,7 +87,7 @@ describe('allowed', () => {
       selectStub = sinon.stub();
       const stubModels = {
         Project: {
-          query: sinon.stub().returns({
+          queryWithDeleted: sinon.stub().returns({
             findById: findStub.returns({
               select: selectStub
             })
@@ -166,21 +166,21 @@ describe('allowed', () => {
       selectStub = sinon.stub();
       const stubModels = {
         PIL: {
-          query: sinon.stub().returns({
+          queryWithDeleted: sinon.stub().returns({
             findById: findStub.returns({
               select: selectStub
             })
           })
         },
         Project: {
-          query: sinon.stub().returns({
+          queryWithDeleted: sinon.stub().returns({
             findById: findStub.returns({
               select: selectStub
             })
           })
         },
         ProjectVersion: {
-          query: sinon.stub().returns({
+          queryWithDeleted: sinon.stub().returns({
             findById: findStub.returns({
               select: selectStub
             })
@@ -330,7 +330,7 @@ describe('allowed', () => {
       selectStub = sinon.stub();
       const stubModels = {
         ProjectVersion: {
-          query: sinon.stub().returns({
+          queryWithDeleted: sinon.stub().returns({
             findById: findStub.returns({
               select: selectStub
             })


### PR DESCRIPTION
* query deleted models when checking permissions
* this is needed if a model is deleted but a permissions check is still run (discarding project amendments and deletion tasks)