### PR TITLE
Handle errors in permissions checks

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -28,7 +28,7 @@ module.exports = settings => {
   });
 
   app.use('/:task', (req, res, next) => {
-    checkPermissions(req.profile, req.params.task, req.query)
+    checkPermissions({ user: req.profile, task: req.params.task, subject: req.query, log: req.log })
       .then(isAllowed => {
         res.allowed = isAllowed;
         next();

--- a/lib/can.js
+++ b/lib/can.js
@@ -4,7 +4,7 @@ const { allowed } = require('./utils');
 const can = ({ db, permissions }) => {
   const isAllowed = allowed({ db });
 
-  return (user, task, subject) => {
+  return ({ user, task, subject, log }) => {
 
     if (!user) {
       const err = new Error('Unknown user');
@@ -20,7 +20,7 @@ const can = ({ db, permissions }) => {
       return Promise.reject(err);
     }
 
-    return isAllowed({ model, user, subject, permissions: settings });
+    return isAllowed({ model, user, subject, permissions: settings, log });
   };
 };
 

--- a/test/allowed.spec.js
+++ b/test/allowed.spec.js
@@ -442,4 +442,52 @@ describe('allowed', () => {
     });
   });
 
+  describe('error handling', () => {
+
+    let stub;
+    let params;
+    const USER_ID = '1efe4fe4-9c9a-4d89-af91-fc5eea0014f1';
+    const PIL_ID = '29ece18a-afeb-4dc9-a02e-734e054a40c7';
+
+    beforeEach(() => {
+      stub = sinon.stub().rejects(new Error('Test'));
+
+      const stubModels = {
+        PIL: {
+          queryWithDeleted: stub
+        }
+      };
+
+      allowed = allowedHelper({ db: stubModels });
+
+      params = {
+        permissions: ['pil:own'],
+        user: {
+          id: USER_ID
+        },
+        subject: {
+          pilId: PIL_ID
+        },
+        log: sinon.stub()
+      };
+    });
+
+    it('returns false if a check throws an error', () => {
+      return Promise.resolve()
+        .then(() => allowed(params))
+        .then(isAllowed => {
+          assert.equal(isAllowed, false);
+        });
+    });
+
+    it('returns logs the error', () => {
+      return Promise.resolve()
+        .then(() => allowed(params))
+        .then(() => {
+          assert.ok(params.log.calledWith('error'), 'error logger should have been called');
+        });
+    });
+
+  });
+
 });


### PR DESCRIPTION
If one particular role in a set of permissions fails then don't fail the entire request, just log the error and return false.