### PR TITLE
Add a cache layer to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ The following environment variables can be optionally defined:
 * `DATABASE_PORT` - port of the postgres instance - default `5432`
 * `DATABASE_USERNAME` - username of the postgres instance - default `undefined`
 * `DATABASE_PASSWORD` - password of the postgres instance - default `undefined`
+* `CACHE_TTL` - ttl for cache, if not set will disable caching - default `undefined`
+* `REDIS_HOST` - hostname for redis cache store
+* `REDIS_PORT` - port for redis cache store
+* `REDIS_PASSWORD` - password for redis cache store
+
+## Caching
+
+An optional cache can be configured by defining a `CACHE_TTL` environment variable. This will attempt to connect to a redis instance to store cache entries, but will fall back to an in memory cache if redis is not configured or cannot connect.
 
 ### Permissions configuration
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The following environment variables can be optionally defined:
 
 An optional cache can be configured by defining a `CACHE_TTL` environment variable. This will attempt to connect to a redis instance to store cache entries, but will fall back to an in memory cache if redis is not configured or cannot connect.
 
+See https://www.npmjs.com/package/apicache#api for configuration options for cache duration
+
 ### Permissions configuration
 
 The allowed roles for each task are defined in [config.js](./config.js). Adding a role to a task grants permission to perform that task to users with that role.

--- a/config.js
+++ b/config.js
@@ -1,5 +1,11 @@
 module.exports = {
   port: process.env.PORT || 8080,
+  cache: process.env.CACHE_TTL,
+  redis: {
+    host: process.env.REDIS_HOST,
+    port: process.env.REDIS_PORT,
+    password: process.env.REDIS_PASSWORD
+  },
   auth: {
     realm: process.env.KEYCLOAK_REALM,
     url: process.env.KEYCLOAK_URL,

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,6 +2,7 @@ const api = require('@asl/service/api');
 const Schema = require('@asl/schema');
 const can = require('./can');
 const tasks = require('./get-tasks');
+const cache = require('./cache');
 
 const errorHandler = require('./error-handler');
 
@@ -14,6 +15,8 @@ module.exports = settings => {
 
   const checkPermissions = can({ permissions: settings.permissions, db });
   const getUserTasks = tasks({ permissions: settings.permissions, db });
+
+  app.use(cache(settings));
 
   app.use((req, res, next) => {
     return Profile.query()

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -6,7 +6,9 @@ module.exports = settings => {
     return (req, res, next) => next();
   }
   const redisClient = redis.createClient(settings.redis);
-  redisClient.on('error', () => {});
+  redisClient.on('error', e => {
+    console.error(`Redis failed with error: ${e.message} - falling back to in-memory cache store`);
+  });
 
   const options = {
     appendKey: req => req.user.id,

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,16 @@
+const Cache = require('apicache');
+const redis = require('redis');
+
+module.exports = settings => {
+  if (!settings.cache) {
+    return (req, res, next) => next();
+  }
+  const redisClient = redis.createClient(settings.redis);
+  redisClient.on('error', () => {});
+
+  const options = {
+    appendKey: req => req.user.id,
+    redisClient
+  };
+  return Cache.options(options).middleware(settings.cache);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1101,6 +1101,23 @@
         "express": "^4.16.2",
         "express-session": "^1.15.6",
         "redis": "^2.8.0"
+      },
+      "dependencies": {
+        "redis": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+          "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+          "requires": {
+            "double-ended-queue": "^2.1.0-0",
+            "redis-commands": "^1.2.0",
+            "redis-parser": "^2.6.0"
+          }
+        },
+        "redis-parser": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+          "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+        }
       }
     },
     "@sinonjs/commons": {
@@ -1232,6 +1249,11 @@
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
       }
+    },
+    "apicache": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.5.3.tgz",
+      "integrity": "sha512-n1h39Bt7tMiJMV0u0tFlhigig8Uo/wJmKoj6WE/OwvZ+WbFchn7jnXleotZOzZTUBtr0Tg9iJshHnJDAGQbAEQ=="
     },
     "aproba": {
       "version": "1.2.0",
@@ -2168,6 +2190,21 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "redis": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+          "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+          "requires": {
+            "double-ended-queue": "^2.1.0-0",
+            "redis-commands": "^1.2.0",
+            "redis-parser": "^2.6.0"
+          }
+        },
+        "redis-parser": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+          "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
         }
       }
     },
@@ -2408,6 +2445,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -6996,13 +7038,14 @@
       }
     },
     "redis": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
+      "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "denque": "^1.4.1",
+        "redis-commands": "^1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
       }
     },
     "redis-commands": {
@@ -7010,10 +7053,18 @@
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
       "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
     },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
     "redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
     },
     "redux": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "@asl/constants": "0.0.1",
     "@asl/schema": "^7.39.0",
     "@asl/service": "^7.13.0",
+    "apicache": "^1.5.3",
     "lodash": "^4.17.15",
     "objection": "^2.1.3",
+    "redis": "^3.0.2",
     "uuid": "^7.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds an optional caching middleware in front of API to prevent thrashing the database when under load.

Connects to a redis store if one is available but falls back to an in-memory store otherwise.