### PR TITLE
Exclude allowed actions endpoint from cache

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -14,5 +14,10 @@ module.exports = settings => {
     appendKey: req => req.user.id,
     redisClient
   };
-  return Cache.options(options).middleware(settings.cache);
+  // exclude allowed actions endpoint from cache
+  // it is called infrequently, but needs to be responsive to change when it is called
+  const nopes = [
+    '/'
+  ];
+  return Cache.options(options).middleware(settings.cache, (req, res) => !nopes.includes(req.path));
 };


### PR DESCRIPTION
This means that the high-level establishment permissions will update instantly when accepting a new establishment invitations.

Since this sits behind an existing cache of the user profile it should have negligible performance impact.