### PR TITLE
Add reporting permission config

### DIFF
--- a/config.js
+++ b/config.js
@@ -85,6 +85,7 @@ module.exports = {
       relatedTasks: ['asru:*', 'establishment:admin']
     },
     asruProfile: ['*'],
-    licenceFees: ['asru:*']
+    licenceFees: ['asru:*'],
+    asruReporting: ['asru:*']
   }
 };


### PR DESCRIPTION
Allows us to deliver the business support role UI without switching off any functionality in the first release.