### PR TITLE
Non-holding admins, ntcos can now download PIL pdf

### DIFF
--- a/config.js
+++ b/config.js
@@ -47,7 +47,7 @@ module.exports = {
     pil: {
       list: ['asru:*', 'establishment:admin', 'establishment:read', 'establishment:role:ntco'],
       read: ['pil:own', 'asru:*', 'establishment:admin', 'establishment:read', 'establishment:role:ntco'],
-      pdf: ['pil:own', 'asru:*', 'holdingEstablishment:admin', 'holdingEstablishment:read'],
+      pdf: ['pil:own', 'asru:*', 'establishment:admin', 'establishment:read', 'establishment:role:ntco'],
       create: ['profile:own', 'establishment:admin'],
       update: ['pil:own', 'holdingEstablishment:admin', 'asru:*'],
       delete: ['pil:own', 'holdingEstablishment:admin'],


### PR DESCRIPTION
This needs to go after the UI changes below so that we don't expose the holding establishment name to users not at the holding establishment.

~https://github.com/UKHomeOffice/asl-pages/pull/885~