### PR TITLE
Prevent missing ids breaking queries

### DIFF
--- a/lib/utils/allowed.js
+++ b/lib/utils/allowed.js
@@ -45,6 +45,11 @@ function roleIsAllowed({ db, model, permission, user: unscoped, subject = {} }) 
 
       async function hasAdditionalAvailability() {
         const id = subject.projectId || subject.id;
+
+        if (!id) {
+          return false;
+        }
+
         const projectEstablishments = await db.ProjectEstablishment.query().where({ projectId: id });
 
         return some(projectEstablishments, pe => {
@@ -187,6 +192,10 @@ function roleIsAllowed({ db, model, permission, user: unscoped, subject = {} }) 
           });
       }
       if (scope === 'projectVersion' && level === 'collaborator') {
+        if (!subject.projectId) {
+          return false;
+        }
+
         const project = await db.Project.queryWithDeleted()
           .whereIsCollaborator(user.id)
           .findById(subject.projectId)


### PR DESCRIPTION
When signing in as an ASRU user, the permissions service is throwing errors when evaluating `additionalEstablishment:admin` and `projectVersion:collaborator` permissions.

This is because it's trying to `findById` for an undefined id.