### PR TITLE
Fix project permissions for additional establishment readonly users

### DIFF
--- a/config.js
+++ b/config.js
@@ -85,10 +85,10 @@ module.exports = {
       relatedTasks: ['holdingEstablishment:admin', 'project:own', 'asru:*']
     },
     projectVersion: {
-      read: ['asru:*', 'holdingEstablishment:admin', 'holdingEstablishment:read', 'project:own', 'additionalEstablishment:admin', 'receivingEstablishment:admin', 'projectVersion:collaborator']
+      read: ['asru:*', 'holdingEstablishment:admin', 'holdingEstablishment:read', 'project:own', 'additionalEstablishment:admin', 'additionalEstablishment:read', 'receivingEstablishment:admin', 'projectVersion:collaborator']
     },
     retrospectiveAssessment: {
-      read: ['asru:*', 'holdingEstablishment:admin', 'holdingEstablishment:read', 'project:own', 'additionalEstablishment:admin', 'receivingEstablishment:admin', 'projectVersion:collaborator'],
+      read: ['asru:*', 'holdingEstablishment:admin', 'holdingEstablishment:read', 'project:own', 'additionalEstablishment:admin', 'additionalEstablishment:read', 'receivingEstablishment:admin', 'projectVersion:collaborator'],
       update: ['holdingEstablishment:admin', 'project:own', 'asru:licensing']
     },
     establishment: {


### PR DESCRIPTION
The `project.read` permission was set for these users, but not the version permission.

Add version level and RA level access for readonly users at additional establishments.