### PR TITLE
Add permissions config for ROPs completion

### DIFF
--- a/config.js
+++ b/config.js
@@ -75,6 +75,9 @@ module.exports = {
       import: ['establishment:*'],
       create: ['profile:own', 'establishment:admin'],
       update: ['holdingEstablishment:admin', 'project:own', 'asru:licensing'],
+      rops: {
+        update: ['asru:licensing']
+      },
       endorse: ['holdingEstablishment:admin'],
       updateConditions: ['asru:*'],
       updateIssueDate: ['asru:licensing'],


### PR DESCRIPTION
Configure this separately from `project.update` so that it's clear from the permissions config which users can complete ROPs.