### PR TITLE
Add legacy stub permissions

### DIFF
--- a/config.js
+++ b/config.js
@@ -88,7 +88,11 @@ module.exports = {
       updateLicenceNumber: ['asru:inspector'],
       delete: ['holdingEstablishment:admin', 'project:own', 'asru:inspector'],
       revoke: ['asru:inspector', 'holdingEstablishment:admin', 'project:own'],
-      convertLegacy: ['asru:inspector'],
+      stub: {
+        create: ['asru:*'],
+        update: ['asru:*'],
+        convert: ['asru:inspector']
+      },
       relatedTasks: ['holdingEstablishment:admin', 'project:own', 'asru:*']
     },
     projectVersion: {


### PR DESCRIPTION
These are currently spready through the codebase as a series of `isLicensing` conditions, which makes them difficult to update.

Add the permissions here so that they can be managed in one place.