### PR TITLE
Allow ROPs analysts to access individual ROPs

### DIFF
--- a/config.js
+++ b/config.js
@@ -78,8 +78,8 @@ module.exports = {
       update: ['holdingEstablishment:admin', 'project:own', 'asru:inspector', 'project:collaborator:edit'],
       submit: ['holdingEstablishment:admin', 'project:own', 'asru:inspector'],
       rops: {
-        update: ['establishment:admin', 'project:own', 'asru:inspector', 'project:collaborator:edit'],
-        submit: ['establishment:admin', 'project:own', 'asru:inspector'],
+        update: ['establishment:admin', 'project:own', 'asru:inspector', 'asru:rops', 'project:collaborator:edit'],
+        submit: ['establishment:admin', 'project:own', 'asru:inspector', 'asru:rops'],
         create: ['asru:inspector']
       },
       endorse: ['holdingEstablishment:admin'],


### PR DESCRIPTION
We don't currently have any way for a returns analyst to view the ROP for a particular project.

They probably don't _need_ write access, but since there's no concept of read-only ROPs usage this will have to do.