### PR TITLE
Add permission for handling reminders

### DIFF
--- a/config.js
+++ b/config.js
@@ -38,6 +38,7 @@ module.exports = {
       global: ['asru:*', 'profile:own'],
       update: ['profile:own'],
       alerts: ['profile:own'],
+      reminders: ['profile:own'],
       permissions: ['asru:*', 'establishment:admin'],
       removePermissions: ['asru:*', 'establishment:admin', 'profile:own'],
       roles: ['asru:*', 'establishment:admin'],


### PR DESCRIPTION
Condition reminders appear to licence holders, which can then be dismissed if no-longer relevant.

External users should only be able to dismiss their own reminders.